### PR TITLE
fix: Implemented dynamic PDF filenames based on competition ID and template

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -436,24 +436,15 @@ function GenerateDocument() {
     }, 100);
 }
 
-function getCompetitionName() {
-    return wcif?.name || "Badges";
+
+function PrintDocument() {
+    const competitionId = wcif?.id || "Badges";
+    const templateName = templates[settings.template]?.name
+        ? templates[settings.template].name.replace(/[^a-zA-Z0-9]/g, '_')
+        : "Badges";
+    globalDoc.save(`${competitionId}_${templateName}.pdf`);
 }
 
-function sanitizeFilename(name) {
-    return name.replace(/[^a-z0-9]/gi, '_').replace(/_+/g, '_');
-}
-// Modified PrintDocument Function 
-function PrintDocument() {
-    const competitionName = sanitizeFilename(getCompetitionName());
-    const templateName = templates[settings.template]?.name.replace(/[^a-z0-9]/gi, '_') || "Badges";
-    const filename = `${competitionName}_${templateName}.pdf`;
-    globalDoc.save(filename);
-}
-/*
-function PrintDocument() {
-    globalDoc.save("Badges.pdf");
-}*/
 
 $(document).ready(function () {
     // Setup template dropdown

--- a/js/main.js
+++ b/js/main.js
@@ -436,9 +436,24 @@ function GenerateDocument() {
     }, 100);
 }
 
+function getCompetitionName() {
+    return wcif?.name || "Badges";
+}
+
+function sanitizeFilename(name) {
+    return name.replace(/[^a-z0-9]/gi, '_').replace(/_+/g, '_');
+}
+// Modified PrintDocument Function 
+function PrintDocument() {
+    const competitionName = sanitizeFilename(getCompetitionName());
+    const templateName = templates[settings.template]?.name.replace(/[^a-z0-9]/gi, '_') || "Badges";
+    const filename = `${competitionName}_${templateName}.pdf`;
+    globalDoc.save(filename);
+}
+/*
 function PrintDocument() {
     globalDoc.save("Badges.pdf");
-}
+}*/
 
 $(document).ready(function () {
     // Setup template dropdown


### PR DESCRIPTION
Changes
- Switched from `wcif.name` to `wcif.id` for competition identifiers.
- Removed helper functions and performed inline sanitization for template names.
- Ensured consistent handling of both competition IDs and template names.
